### PR TITLE
feat: add `missing` option to customize the definition of missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ interface NormalizerOptions {
   unknown?: UnknownHandler;
   invalid?: InvalidHandler;
   deprecated?: DeprecatedHandler;
+  missing?: IdentifyMissing;
 }
 ```
 
@@ -140,6 +141,16 @@ type DeprecatedHandler = (
 ```
 
 Returns a deprecation warning.
+
+#### IdentifyMissing
+
+Defaults to `(key, options) => !(key in options)`.
+
+```ts
+type IdentifyMissing = (key: string, options: Options) => boolean;
+```
+
+Returns a boolean to indicate if `key` is _missing_ in `options`.
 
 ### Schemas
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export type DeprecatedHandler = (
   utils: Utils,
 ) => string;
 
+export type IdentifyMissing = (key: string, options: Options) => boolean;
+
 export type OptionKey = string;
 export type OptionValue = any;
 export interface OptionPair {

--- a/tests/inedx.test.ts
+++ b/tests/inedx.test.ts
@@ -1,4 +1,5 @@
 import * as vnopts from '../src';
+import { IdentifyMissing } from '../src';
 import { createLogger } from './__helpers__/utils';
 
 const logger = createLogger();
@@ -46,4 +47,35 @@ test('redirect', () => {
     vnopts.normalize({ parser: 'postcss' }, schemas, { logger }),
   ).toMatchSnapshot();
   expect(logger.getMessages()).toMatchSnapshot();
+});
+
+describe('missing', () => {
+  const name = 'a';
+  const missing: IdentifyMissing = (key, options) => options[key] === undefined;
+
+  test('missing pair will be filtered', () => {
+    expect(
+      vnopts.normalize(
+        { [name]: undefined },
+        [vnopts.createSchema(vnopts.AnySchema, { name, validate: false })],
+        { missing },
+      ),
+    ).toEqual({});
+  });
+
+  test('missing pair will be replaced by default pair if present', () => {
+    const defaultValue = 'foo';
+    expect(
+      vnopts.normalize(
+        { [name]: undefined },
+        [
+          vnopts.createSchema(vnopts.AnySchema, {
+            name,
+            default: { value: defaultValue },
+          }),
+        ],
+        { missing },
+      ),
+    ).toEqual({ a: defaultValue });
+  });
 });


### PR DESCRIPTION
```ts
missing?: (key: string, options: Options) => boolean;
```

defaults to `(key, options) => !(key in options)`