### PR TITLE
feat: add `required` option to throw if the required key is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ interface NormalizerOptions {
   invalid?: InvalidHandler;
   deprecated?: DeprecatedHandler;
   missing?: IdentifyMissing;
+  required?: IdentifyRequired;
 }
 ```
 
@@ -144,13 +145,24 @@ Returns a deprecation warning.
 
 #### IdentifyMissing
 
-Defaults to `(key, options) => !(key in options)`.
+Defaults to `() => false`.
 
 ```ts
 type IdentifyMissing = (key: string, options: Options) => boolean;
 ```
 
 Returns a boolean to indicate if `key` is _missing_ in `options`.
+(`!(key in options)` is always considered missing.)
+
+#### IdentifyRequired
+
+Defaults to `() => false`.
+
+```ts
+type IdentifyRequired = (key: string) => boolean;
+```
+
+Returns a boolean to indicate if `key` is required in the output.
 
 ### Schemas
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const VALUE_NOT_EXIST = Symbol.for('vnopts.VALUE_NOT_EXIST');

--- a/src/handlers/invalid/common.ts
+++ b/src/handlers/invalid/common.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
+import { VALUE_NOT_EXIST } from '../../constants';
 import { InvalidHandler } from '../../types';
 
 export const commonInvalidHandler: InvalidHandler = (key, value, utils) =>
   [
     `Invalid ${chalk.red(utils.descriptor.key(key))} value.`,
     `Expected ${chalk.blue(utils.schemas[key].expected(utils))},`,
-    `but received ${chalk.red(utils.descriptor.value(value))}.`,
+    `but received ${
+      value === VALUE_NOT_EXIST
+        ? chalk.gray('nothing')
+        : chalk.red(utils.descriptor.value(value))
+    }.`,
   ].join(' ');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './descriptors';
 export * from './handlers';
 export * from './schemas';
 
+export * from './constants';
 export * from './normalize';
 export * from './schema';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export type InvalidHandler = (
   value: OptionValue,
   utils: Utils,
 ) => string | Error;
+export type NormalizedInvalidHandler = (
+  key: OptionKey,
+  value: OptionValue,
+  utils: Utils,
+) => Error;
 
 export type DeprecatedHandler = (
   keyOrPair: OptionKey | OptionPair,
@@ -48,6 +53,7 @@ export type DeprecatedHandler = (
 ) => string;
 
 export type IdentifyMissing = (key: string, options: Options) => boolean;
+export type IdentifyRequired = (key: string) => boolean;
 
 export type OptionKey = string;
 export type OptionValue = any;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,12 @@ import {
   DefaultResult,
   DeprecatedResult,
   ForwardResult,
+  InvalidHandler,
   NormalizedDefaultResult,
   NormalizedDeprecatedResult,
   NormalizedDeprecatedResultWithTrue,
   NormalizedForwardResult,
+  NormalizedInvalidHandler,
   NormalizedRedirectResult,
   NormalizedTransferResult,
   NormalizedValidateResult,
@@ -123,6 +125,17 @@ export function comparePrimitive(
   }
 
   return (a as string).localeCompare(b as string);
+}
+
+export function normalizeInvalidHandler(
+  invalidHandler: InvalidHandler,
+): NormalizedInvalidHandler {
+  return (...args) => {
+    const errorMessageOrError = invalidHandler(...args);
+    return typeof errorMessageOrError === 'string'
+      ? new Error(errorMessageOrError)
+      : /* istanbul ignore next*/ errorMessageOrError;
+  };
 }
 
 export function normalizeDefaultResult<$Value>(

--- a/tests/__snapshots__/inedx.test.ts.snap
+++ b/tests/__snapshots__/inedx.test.ts.snap
@@ -23,3 +23,5 @@ Array [
   "{ parser: \\"postcss\\" } is deprecated; we now treat it as { parser: \\"css\\" }.",
 ]
 `;
+
+exports[`required 1`] = `"Invalid \\"<key>\\" value. Expected anything, but received nothing."`;

--- a/tests/inedx.test.ts
+++ b/tests/inedx.test.ts
@@ -79,3 +79,13 @@ describe('missing', () => {
     ).toEqual({ a: defaultValue });
   });
 });
+
+test('required', () => {
+  expect(() =>
+    vnopts.normalize(
+      {},
+      [vnopts.createSchema(vnopts.AnySchema, { name: '<key>' })],
+      { required: () => true },
+    ),
+  ).toThrowErrorMatchingSnapshot();
+});


### PR DESCRIPTION
- defaults to `() => false`
  ```ts
  required?: (key: string) => boolean;
  ```
- `IdentifyMissing` now implies `!(key in options)`
- add `VALUE_NOT_EXIST` to distinguish missing and invalid in `InvalidHandler`