### PR TITLE
feat: add `preprocess`/`postprocess` option

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const VALUE_NOT_EXIST = Symbol.for('vnopts.VALUE_NOT_EXIST');
+export const VALUE_UNCHANGED = Symbol.for('vnopts.VALUE_UNCHANGED');

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,4 @@
-import { VALUE_NOT_EXIST } from './constants';
+import { VALUE_UNCHANGED, VALUE_NOT_EXIST } from './constants';
 import {
   defaultDeprecatedHandler,
   defaultDescriptor,
@@ -15,8 +15,10 @@ import {
   Logger,
   NormalizedInvalidHandler,
   NormalizedTransferResult,
+  OptionKey,
   OptionPair,
   Options,
+  OptionValue,
   TransferTo,
   UnknownHandler,
   Utils,
@@ -41,6 +43,8 @@ export interface NormalizerOptions {
   deprecated?: DeprecatedHandler;
   missing?: IdentifyMissing;
   required?: IdentifyRequired;
+  preprocess?: (options: Options) => Options;
+  postprocess?: (options: Options) => Options | typeof VALUE_UNCHANGED;
 }
 
 export const normalize = (
@@ -57,6 +61,10 @@ export class Normalizer {
   private _hasDeprecationWarned!: ReturnType<typeof createAutoChecklist>;
   private _identifyMissing: IdentifyMissing;
   private _identifyRequired: IdentifyRequired;
+  private _preprocess: (options: Options) => Options;
+  private _postprocess: (
+    options: Options,
+  ) => Options | typeof VALUE_UNCHANGED;
 
   constructor(schemas: Array<Schema<any>>, opts?: NormalizerOptions) {
     // istanbul ignore next
@@ -68,6 +76,8 @@ export class Normalizer {
       deprecated = defaultDeprecatedHandler,
       missing = () => false,
       required = () => false,
+      preprocess = (x: Options) => x,
+      postprocess = (): typeof VALUE_UNCHANGED => VALUE_UNCHANGED,
     } = opts || {};
 
     this._utils = {
@@ -86,6 +96,8 @@ export class Normalizer {
     this._deprecatedHandler = deprecated;
     this._identifyMissing = (k, o) => !(k in o) || missing(k, o);
     this._identifyRequired = required;
+    this._preprocess = preprocess;
+    this._postprocess = postprocess;
 
     this.cleanHistory();
   }
@@ -95,15 +107,17 @@ export class Normalizer {
   }
 
   public normalize(options: Options): Options {
-    const normalized: Options = {};
-    const restOptionsArray = [options];
+    const newOptions: Options = {};
+
+    const preprocessed = this._preprocess(options);
+    const restOptionsArray = [preprocessed];
 
     const applyNormalization = () => {
       while (restOptionsArray.length !== 0) {
         const currentOptions = restOptionsArray.shift()!;
         const transferredOptionsArray = this._applyNormalization(
           currentOptions,
-          normalized,
+          newOptions,
         );
         restOptionsArray.push(...transferredOptionsArray);
       }
@@ -113,7 +127,7 @@ export class Normalizer {
 
     for (const key of Object.keys(this._utils.schemas)) {
       const schema = this._utils.schemas[key];
-      if (!(key in normalized)) {
+      if (!(key in newOptions)) {
         const defaultResult = normalizeDefaultResult(
           schema.default(this._utils),
         );
@@ -126,43 +140,44 @@ export class Normalizer {
     applyNormalization();
 
     for (const key of Object.keys(this._utils.schemas)) {
+      if (!(key in newOptions)) {
+        continue;
+      }
+
       const schema = this._utils.schemas[key];
-      if (key in normalized) {
-        normalized[key] = schema.postprocess(normalized[key], this._utils);
+
+      const value = newOptions[key];
+      const newValue = schema.postprocess(value, this._utils);
+
+      if (newValue === VALUE_UNCHANGED) {
+        continue;
       }
+
+      this._applyValidation(newValue, key, schema);
+
+      newOptions[key] = newValue;
     }
 
-    for (const key of Object.keys(this._utils.schemas)) {
-      if (!(key in normalized) && this._identifyRequired(key)) {
-        throw this._invalidHandler(key, VALUE_NOT_EXIST, this._utils);
-      }
-    }
+    const postprocessed = this._applyPostprocess(newOptions);
 
-    return normalized;
+    this._applyRequiredCheck(postprocessed);
+
+    return postprocessed;
   }
 
   private _applyNormalization(
     options: Options,
-    normalized: Options,
+    newOptions: Options,
   ): Options[] {
     const transferredOptionsArray: Options[] = [];
 
-    const [knownOptionNames, unknownOptionNames] = partition(
-      Object.keys(options).filter(key => !this._identifyMissing(key, options)),
-      key => key in this._utils.schemas,
-    );
+    const { knownKeys, unknownKeys } = this._partitionOptionKeys(options);
 
-    for (const key of knownOptionNames) {
+    for (const key of knownKeys) {
       const schema = this._utils.schemas[key];
       const value = schema.preprocess(options[key], this._utils);
 
-      const validateResult = normalizeValidateResult(
-        schema.validate(value, this._utils),
-        value,
-      );
-      if (validateResult !== true) {
-        throw this._invalidHandler(key, validateResult.value, this._utils);
-      }
+      this._applyValidation(value, key, schema);
 
       const appendTransferredOptions = <$Value>(
         { from, to }: NormalizedTransferResult<$Value>, //
@@ -228,9 +243,9 @@ export class Normalizer {
       if ('remain' in redirectResult) {
         const remainingValue = redirectResult.remain!;
 
-        normalized[key] =
-          key in normalized
-            ? schema.overlap(normalized[key], remainingValue, this._utils)
+        newOptions[key] =
+          key in newOptions
+            ? schema.overlap(newOptions[key], remainingValue, this._utils)
             : remainingValue;
 
         warnDeprecated({ value: remainingValue });
@@ -241,22 +256,114 @@ export class Normalizer {
       }
     }
 
-    for (const key of unknownOptionNames) {
+    for (const key of unknownKeys) {
       const value = options[key];
-
-      const unknownResult = this._unknownHandler(key, value, this._utils);
-      if (unknownResult) {
-        for (const unknownKey of Object.keys(unknownResult)) {
-          const unknownOption = { [unknownKey]: unknownResult[unknownKey] };
-          if (unknownKey in this._utils.schemas) {
-            transferredOptionsArray.push(unknownOption);
-          } else {
-            Object.assign(normalized, unknownOption);
-          }
-        }
-      }
+      this._applyUnknownHandler(
+        key,
+        value,
+        newOptions,
+        (knownResultKey, knownResultValue) => {
+          transferredOptionsArray.push({ [knownResultKey]: knownResultValue });
+        },
+      );
     }
 
     return transferredOptionsArray;
+  }
+
+  private _applyRequiredCheck(options: Options) {
+    for (const key of Object.keys(this._utils.schemas)) {
+      if (this._identifyMissing(key, options)) {
+        if (this._identifyRequired(key)) {
+          throw this._invalidHandler(key, VALUE_NOT_EXIST, this._utils);
+        }
+      }
+    }
+  }
+
+  private _partitionOptionKeys(options: Options) {
+    const [knownKeys, unknownKeys] = partition(
+      Object.keys(options).filter(key => !this._identifyMissing(key, options)),
+      key => key in this._utils.schemas,
+    );
+    return { knownKeys, unknownKeys };
+  }
+
+  private _applyValidation(value: unknown, key: string, schema: Schema<any>) {
+    const validateResult = normalizeValidateResult(
+      schema.validate(value, this._utils),
+      value,
+    );
+    if (validateResult !== true) {
+      throw this._invalidHandler(key, validateResult.value, this._utils);
+    }
+  }
+
+  private _applyUnknownHandler(
+    key: OptionKey,
+    value: OptionValue,
+    newOptions: Options,
+    knownResultHandler: (key: OptionKey, value: OptionValue) => void,
+  ) {
+    const unknownResult = this._unknownHandler(key, value, this._utils);
+
+    if (!unknownResult) {
+      return;
+    }
+
+    for (const resultKey of Object.keys(unknownResult)) {
+      if (this._identifyMissing(resultKey, unknownResult)) {
+        continue;
+      }
+
+      const resultValue = unknownResult[resultKey];
+      if (resultKey in this._utils.schemas) {
+        knownResultHandler(resultKey, resultValue);
+      } else {
+        newOptions[resultKey] = resultValue;
+      }
+    }
+  }
+
+  private _applyPostprocess(options: Options) {
+    const postprocessedResult = this._postprocess(options);
+
+    if (postprocessedResult === VALUE_UNCHANGED) {
+      return options;
+    }
+
+    const postprocessed = postprocessedResult;
+
+    const { knownKeys, unknownKeys } = this._partitionOptionKeys(postprocessed);
+
+    for (const key of knownKeys) {
+      this._applyValidation(postprocessed[key], key, this._utils.schemas[key]);
+    }
+
+    if (unknownKeys.length === 0) {
+      return postprocessed;
+    }
+
+    const newPostprocessed: Options = {};
+
+    for (const key of knownKeys) {
+      newPostprocessed[key] = postprocessed[key];
+    }
+
+    for (const key of unknownKeys) {
+      const value = postprocessed[key];
+      this._applyUnknownHandler(
+        key,
+        value,
+        newPostprocessed,
+        (knownResultKey, knownResultValue) => {
+          const schema = this._utils.schemas[knownResultKey];
+          this._applyValidation(knownResultValue, knownResultKey, schema);
+          newPostprocessed[knownResultKey] = knownResultValue;
+        },
+      );
+    }
+
+    return newPostprocessed;
   }
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,4 @@
-import { VALUE_UNCHANGED, VALUE_NOT_EXIST } from './constants';
+import { VALUE_NOT_EXIST, VALUE_UNCHANGED } from './constants';
 import {
   defaultDeprecatedHandler,
   defaultDescriptor,
@@ -62,9 +62,7 @@ export class Normalizer {
   private _identifyMissing: IdentifyMissing;
   private _identifyRequired: IdentifyRequired;
   private _preprocess: (options: Options) => Options;
-  private _postprocess: (
-    options: Options,
-  ) => Options | typeof VALUE_UNCHANGED;
+  private _postprocess: (options: Options) => Options | typeof VALUE_UNCHANGED;
 
   constructor(schemas: Array<Schema<any>>, opts?: NormalizerOptions) {
     // istanbul ignore next

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,3 +1,4 @@
+import { VALUE_UNCHANGED } from './constants';
 import {
   DefaultResult,
   DeprecatedResult,
@@ -155,12 +156,12 @@ export abstract class Schema<
     return currentValue;
   }
 
-  public preprocess(value: unknown, _utils: Utils): unknown {
+  public preprocess(value: unknown, _utils: Utils): any {
     return value;
   }
 
-  public postprocess(value: $Value, _utils: Utils): unknown {
-    return value;
+  public postprocess(_value: $Value, _utils: Utils): any {
+    return VALUE_UNCHANGED;
   }
 }
 

--- a/tests/__snapshots__/inedx.test.ts.snap
+++ b/tests/__snapshots__/inedx.test.ts.snap
@@ -12,6 +12,8 @@ Array [
 ]
 `;
 
+exports[`postprocess schema throw error for invalid postprocessed value 1`] = `"Invalid \\"<key>\\" value. Expected \\"<valid-value-1>\\", but received \\"<invalid-value>\\"."`;
+
 exports[`redirect 1`] = `
 Object {
   "parser": "css",


### PR DESCRIPTION
- `preprocess`: process the options before validation
- `postprocess`: process the options before applying the `required` check
- add `VALUE_UNCHANGED` to identify unchanged value from `postprocess`
- postprocessed options will be validated
- unknown option in postprocessed options will be handled
- transfers won't be applied to postprocessed options