### PR TITLE
feat: tweak the return type of `postprocess` for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ interface NormalizerOptions {
   postprocess?: (
     options: Options,
     utils: Utils,
-  ) => Options | typeof VALUE_UNCHANGED;
+  ) => typeof VALUE_UNCHANGED | { delete?: string[]; override?: Options };
 }
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,10 +60,10 @@ export type IdentifyMissing = (key: string, options: Options) => boolean;
 export type IdentifyRequired = (key: string) => boolean;
 
 export type Preprocess = (options: Options, utils: Utils) => Options;
-export type Postprocess = (
-  options: Options,
-  utils: Utils,
-) => Options | typeof VALUE_UNCHANGED;
+export type Postprocess = (options: Options, utils: Utils) => PostprocessResult;
+export type PostprocessResult =
+  | typeof VALUE_UNCHANGED
+  | { delete?: string[]; override?: Options };
 
 export type OptionKey = string;
 export type OptionValue = any;

--- a/tests/inedx.test.ts
+++ b/tests/inedx.test.ts
@@ -129,7 +129,21 @@ describe('postprocess', () => {
   });
 
   describe('normalizer', () => {
-    test('throw invalid postprocess value', () => {
+    test('delete', () => {
+      expect(
+        vnopts.normalize(
+          { [name]: validValue1 },
+          [
+            vnopts.createSchema(vnopts.ChoiceSchema, {
+              name,
+              choices: [validValue1],
+            }),
+          ],
+          { postprocess: () => ({ delete: [name] }) },
+        ),
+      ).toEqual({});
+    });
+    test('throw invalid override value', () => {
       expect(() =>
         vnopts.normalize(
           {},
@@ -139,13 +153,13 @@ describe('postprocess', () => {
               choices: [validValue1],
             }),
           ],
-          { postprocess: () => ({ [name]: invalidValue }) },
+          { postprocess: () => ({ override: { [name]: invalidValue } }) },
         ),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Invalid \\"<key>\\" value. Expected \\"<valid-value-1>\\", but received \\"<invalid-value>\\"."`,
       );
     });
-    test('throw invalid value from postprocessed unknownHandler result', () => {
+    test('throw invalid override value from unknownHandler result', () => {
       expect(() =>
         vnopts.normalize(
           {},
@@ -156,7 +170,7 @@ describe('postprocess', () => {
             }),
           ],
           {
-            postprocess: () => ({ unknown: true }),
+            postprocess: () => ({ override: { unknown: true } }),
             unknown: () => ({ [name]: invalidValue }),
           },
         ),
@@ -164,7 +178,7 @@ describe('postprocess', () => {
         `"Invalid \\"<key>\\" value. Expected \\"<valid-value-1>\\", but received \\"<invalid-value>\\"."`,
       );
     });
-    test('apply valid value from postprocessed unknownHandler result', () => {
+    test('apply valid override value from unknownHandler result', () => {
       expect(
         vnopts.normalize(
           {},
@@ -176,7 +190,7 @@ describe('postprocess', () => {
             vnopts.createSchema(vnopts.AnySchema, { name: 'known' }),
           ],
           {
-            postprocess: () => ({ known: true, unknown: true }),
+            postprocess: () => ({ override: { known: true, unknown: true } }),
             unknown: () => ({ [name]: validValue1 }),
           },
         ),
@@ -185,7 +199,7 @@ describe('postprocess', () => {
         vnopts.normalize(
           {},
           [vnopts.createSchema(vnopts.AnySchema, { name: 'known' })],
-          { postprocess: () => ({ known: true }) },
+          { postprocess: () => ({ override: { known: true } }) },
         ),
       ).toEqual({ known: true });
     });


### PR DESCRIPTION
```diff
-postprocess?: (options, utils) => VALUE_UNCHANGED | Options;
+postprocess?: (options, utils) => VALUE_UNCHANGED | { delete?: string[], override?: Options };
```